### PR TITLE
Fixes error when rewinding an empty map

### DIFF
--- a/src/AbstractBaseMap.php
+++ b/src/AbstractBaseMap.php
@@ -236,7 +236,16 @@ abstract class AbstractBaseMap extends AbstractBaseContainer implements
     {
         $iterator = $this->_getIterator();
         $iterator->rewind();
-        $this->_setIteration($this->_createIteration($iterator->key(), $iterator->current()));
+
+        $key = $iterator->valid()
+            ? $iterator->key()
+            : null;
+
+        $val = $iterator->valid()
+            ? $iterator->current()
+            : null;
+
+        $this->_setIteration($this->_createIteration($key, $val));
     }
 
     /**

--- a/src/AbstractBaseMap.php
+++ b/src/AbstractBaseMap.php
@@ -188,7 +188,7 @@ abstract class AbstractBaseMap extends AbstractBaseContainer implements
      */
     public function rewind()
     {
-        $this->_reset();
+        $this->_rewind();
     }
 
     /**
@@ -245,7 +245,9 @@ abstract class AbstractBaseMap extends AbstractBaseContainer implements
             ? $iterator->current()
             : null;
 
-        $this->_setIteration($this->_createIteration($key, $val));
+        $iteration = $this->_createIteration($key, $val);
+
+        return $iteration;
     }
 
     /**


### PR DESCRIPTION
Fixes #3, and also fixes usage of the abstract iterator functionality for rewinding.